### PR TITLE
fixed missing onNodeDrop prop to child TreeNodes

### DIFF
--- a/src/Tree/TreeNode/index.js
+++ b/src/Tree/TreeNode/index.js
@@ -103,7 +103,7 @@ const TreeNode = DropTarget(DNDType, treeNodeDropSpec, treeNodeDropCollect)(
               {
                 this.props.node.children.map((child, childIndex) => {
                   return (
-                    <TreeNode key={childIndex} node={child} nodeIndex={childIndex} />
+                    <TreeNode key={childIndex} node={child} nodeIndex={childIndex} onNodeDrop={this.props.onNodeDrop} />
                   )
                 })
               }


### PR DESCRIPTION
renderChildren method can now effectively pass the onNodeDrop prop to rendered child nodes